### PR TITLE
fix: make the web3 interface extendable

### DIFF
--- a/src/connector/web3-provider.connector.ts
+++ b/src/connector/web3-provider.connector.ts
@@ -2,9 +2,14 @@ import {ProviderConnector, SolStructType} from './provider.connector';
 import {AbiItem} from '../model/abi.model';
 import {Interface, defaultAbiCoder, ParamType} from 'ethers/lib/utils';
 
+export interface IWeb3CallInfo {
+    data: string,
+    to: string
+}
+
 export interface IWeb3 {
     eth: {
-        call(callInfo: { data: string, to: string }, blockNumber: number | string): Promise<string>
+        call(callInfo: IWeb3CallInfo, blockNumber: number | string): Promise<string>
     }
 }
 

--- a/src/connector/web3-provider.connector.ts
+++ b/src/connector/web3-provider.connector.ts
@@ -2,14 +2,14 @@ import {ProviderConnector, SolStructType} from './provider.connector';
 import {AbiItem} from '../model/abi.model';
 import {Interface, defaultAbiCoder, ParamType} from 'ethers/lib/utils';
 
-type Web3 = {
+export interface IWeb3 {
     eth: {
         call(callInfo: { data: string, to: string }, blockNumber: number | string): Promise<string>
     }
 }
 
 export class Web3ProviderConnector implements ProviderConnector {
-    constructor(protected readonly web3Provider: Web3) {
+    constructor(protected readonly web3Provider: IWeb3) {
     }
 
     contractEncodeABI(


### PR DESCRIPTION
IWeb3 and I prefixing - naming negotiatable


Wanna achieve something like this 

```
import {Web3ProviderConnector} from '1inch/multicall';

declare module '1inch/multicall' {
    interface IWeb3CallInfo {
        ololol: string
        someNewField: string
    }
}

class OlololProvider extends Web3ProviderConnector {
    ethCall(
        contractAddress: string,
        callData: string,
        blockNumber = 'latest'
    ): Promise<string> {
        return this.web3Provider.eth.call(
            {
                to: contractAddress,
                data: callData,
                ololol: 'ololol',
                someNewField: 'someNewField'
            },
            blockNumber
        );
    }
}
```

required to support custom eth call, for example

```
 return this.web3Provider.eth.call(
            {
                to: contractAddress,
                data: callData,
                maxFeePerGas: '50000000000000',
                maxPriorityFeePerGas: '0',
                gas: 100000000
            },
            blockNumber
        )
```